### PR TITLE
Add metatag viewport to enable mobile scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
     <meta name="author" content="spilymp">
     <meta name="description" content="An simple Icon Builder for Odoo (IBO), which provide the ability to create app icons in the style of the appicons of the ERP system Odoo.">
 
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
     <link rel="stylesheet" type="text/css" href="css/milligram.min.css">
     <link rel="stylesheet" type="text/css" href="css/style.css">
 


### PR DESCRIPTION
This change tells browsers to scale the viewport to the device-width.
That enables mobile platforms to scale to their correct width.